### PR TITLE
Add AR Lego analysis skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ yarn-error.log*
 .pnp.js
 
 .vscode/*
+
+dist

--- a/public/index.html
+++ b/public/index.html
@@ -2,9 +2,16 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>Title</title>
+    <title>Lego Network Analyzer</title>
 </head>
 <body>
-
+    <h1>Lego Network Analyzer</h1>
+    <video id="video" autoplay playsinline width="640" height="480"></video>
+    <canvas id="capture" style="display:none;"></canvas>
+    <div>
+        <button id="captureBtn">Capture</button>
+    </div>
+    <pre id="result"></pre>
+    <script src="/bundle.js"></script>
 </body>
 </html>

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,17 @@
-console.log('Happy developing ✨')
+import { VisionApp } from '@modules/vision';
+import { bindButton, showMessage } from '@modules/ui';
+import './styles.css';
+
+window.addEventListener('DOMContentLoaded', async () => {
+  const video = document.getElementById('video') as HTMLVideoElement;
+  const canvas = document.getElementById('capture') as HTMLCanvasElement;
+  const button = document.getElementById('captureBtn') as HTMLButtonElement;
+
+  const app = new VisionApp(video, canvas);
+  await app.start();
+  showMessage('Camera ready. Click capture to analyze.');
+  bindButton(button, async () => {
+    await app.analyze();
+    showMessage('Check console for results');
+  });
+});

--- a/src/modules/camera.ts
+++ b/src/modules/camera.ts
@@ -1,0 +1,17 @@
+export class Camera {
+  constructor(private video: HTMLVideoElement) {}
+
+  async start(): Promise<void> {
+    const stream = await navigator.mediaDevices.getUserMedia({ video: { facingMode: 'environment' }, audio: false });
+    this.video.srcObject = stream;
+    await this.video.play();
+  }
+
+  capture(target: HTMLCanvasElement): CanvasRenderingContext2D {
+    target.width = this.video.videoWidth;
+    target.height = this.video.videoHeight;
+    const ctx = target.getContext('2d')!;
+    ctx.drawImage(this.video, 0, 0, target.width, target.height);
+    return ctx;
+  }
+}

--- a/src/modules/firebase.ts
+++ b/src/modules/firebase.ts
@@ -1,0 +1,16 @@
+import { initializeApp } from 'firebase/app';
+import { getAuth } from 'firebase/auth';
+import { getFirestore } from 'firebase/firestore';
+
+const firebaseConfig = {
+  apiKey: 'YOUR_FIREBASE_API_KEY',
+  authDomain: 'YOUR_AUTH_DOMAIN',
+  projectId: 'YOUR_PROJECT_ID',
+  storageBucket: 'YOUR_STORAGE_BUCKET',
+  messagingSenderId: 'YOUR_SENDER_ID',
+  appId: 'YOUR_APP_ID'
+};
+
+export const app = initializeApp(firebaseConfig);
+export const auth = getAuth(app);
+export const db = getFirestore(app);

--- a/src/modules/segmentation.ts
+++ b/src/modules/segmentation.ts
@@ -1,0 +1,20 @@
+import { FilesetResolver, ImageSegmenter, ImageSegmenterResult } from '@mediapipe/tasks-vision';
+
+const ROBOFLOW_API_KEY = 'rf_wTNbY7mGHVVON6FGybQgsKPfmkP2';
+const MODEL_URL = `https://storage.googleapis.com/mediapipe-models/image_segmenter/deeplab_v3/float32/1/deeplab_v3.tflite?api_key=${ROBOFLOW_API_KEY}`;
+
+export class LegoSegmenter {
+  private segmenter?: ImageSegmenter;
+
+  async init() {
+    const vision = await FilesetResolver.forVisionTasks(
+      'https://cdn.jsdelivr.net/npm/@mediapipe/tasks-vision/wasm'
+    );
+    this.segmenter = await ImageSegmenter.createFromModelPath(vision, MODEL_URL);
+  }
+
+  async segment(image: HTMLCanvasElement): Promise<ImageSegmenterResult | null> {
+    if (!this.segmenter) return null;
+    return this.segmenter.segment(image);
+  }
+}

--- a/src/modules/ui.ts
+++ b/src/modules/ui.ts
@@ -1,0 +1,10 @@
+export function bindButton(button: HTMLButtonElement, handler: () => void) {
+  button.addEventListener('click', handler);
+}
+
+export function showMessage(text: string) {
+  const el = document.getElementById('result');
+  if (el) {
+    el.textContent = text;
+  }
+}

--- a/src/modules/vision.ts
+++ b/src/modules/vision.ts
@@ -1,0 +1,31 @@
+import { Camera } from '@modules/camera';
+import { LegoSegmenter } from '@modules/segmentation';
+import { prominent } from 'color.js';
+
+export class VisionApp {
+  private camera: Camera;
+  private segmenter: LegoSegmenter;
+  private capturingCanvas: HTMLCanvasElement;
+
+  constructor(private video: HTMLVideoElement, canvas: HTMLCanvasElement) {
+    this.camera = new Camera(video);
+    this.segmenter = new LegoSegmenter();
+    this.capturingCanvas = canvas;
+  }
+
+  async start() {
+    await this.camera.start();
+    await this.segmenter.init();
+  }
+
+  async analyze() {
+    const ctx = this.camera.capture(this.capturingCanvas);
+    const result = await this.segmenter.segment(this.capturingCanvas);
+    if (!result) return;
+
+    const data = ctx.getImageData(0, 0, this.capturingCanvas.width, this.capturingCanvas.height);
+    const color = await prominent(data, { amount: 1 });
+    console.log('Dominant color:', color);
+    console.log('Segmentation result:', result);
+  }
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,0 +1,22 @@
+body {
+  font-family: Arial, sans-serif;
+  text-align: center;
+  margin: 0;
+  padding: 0;
+}
+
+video {
+  margin-top: 1rem;
+  border: 1px solid #ccc;
+}
+
+button {
+  margin-top: 1rem;
+  padding: 0.5rem 1rem;
+}
+
+pre {
+  text-align: left;
+  margin: 1rem auto;
+  width: 640px;
+}


### PR DESCRIPTION
## Summary
- add simple HTML UI for capturing network board
- implement camera and segmentation modules
- hook up minimal vision pipeline for analysis
- add placeholder firebase config and basic styles
- ignore build artifacts

## Testing
- `npm run tsc:build`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68521fd3c0c08330835614c242ad0e69