### PR TITLE
Use dotenv for Firebase and Roboflow keys

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+FIREBASE_API_KEY=your-firebase-api-key
+FIREBASE_AUTH_DOMAIN=your-auth-domain
+FIREBASE_PROJECT_ID=your-project-id
+FIREBASE_STORAGE_BUCKET=your-storage-bucket
+FIREBASE_MESSAGING_SENDER_ID=your-messaging-sender-id
+FIREBASE_APP_ID=your-app-id
+FIREBASE_MEASUREMENT_ID=your-measurement-id
+ROBOFLOW_API_KEY=your-roboflow-api-key

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ yarn-error.log*
 .vscode/*
 
 dist
+
+.env

--- a/README.md
+++ b/README.md
@@ -1,0 +1,30 @@
+# Project
+
+## Setup
+
+1. Copy `.env.example` to `.env` and fill in your Firebase and Roboflow credentials.
+   ```bash
+   cp .env.example .env
+   # edit .env and add your keys
+   ```
+2. Install dependencies:
+   ```bash
+   npm install
+   ```
+3. Run the development server:
+   ```bash
+   npm start
+   ```
+
+The application relies on the following environment variables:
+
+- `FIREBASE_API_KEY`
+- `FIREBASE_AUTH_DOMAIN`
+- `FIREBASE_PROJECT_ID`
+- `FIREBASE_STORAGE_BUCKET`
+- `FIREBASE_MESSAGING_SENDER_ID`
+- `FIREBASE_APP_ID`
+- `FIREBASE_MEASUREMENT_ID`
+- `ROBOFLOW_API_KEY`
+
+These values are loaded using `dotenv` and injected during the webpack build.

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
       },
       "devDependencies": {
         "css-loader": "^7.1.2",
+        "dotenv": "^16.5.0",
         "style-loader": "^4.0.0",
         "ts-loader": "^9.5.2",
         "typescript": "^5.8.3",
@@ -2027,6 +2028,19 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
+      "integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "devDependencies": {
     "css-loader": "^7.1.2",
+    "dotenv": "^16.5.0",
     "style-loader": "^4.0.0",
     "ts-loader": "^9.5.2",
     "typescript": "^5.8.3",

--- a/src/custom.d.ts
+++ b/src/custom.d.ts
@@ -2,3 +2,7 @@ declare module '@mediapipe/segmentation';
 declare module 'quantize';
 declare module 'color.js';
 declare module 'perspective-transform';
+
+declare const process: {
+  env: { [key: string]: string };
+};

--- a/src/modules/firebase.ts
+++ b/src/modules/firebase.ts
@@ -4,13 +4,13 @@ import { getFirestore } from 'firebase/firestore';
 import { getAnalytics } from "firebase/analytics";
 
 const firebaseConfig = {
-  apiKey: 'AIzaSyAHwfnuP5J8uVATBUxnwVhPnnbvDkP1gI4',
-  authDomain: 'internet-fundamental-guider.firebaseapp.com',
-  projectId: 'internet-fundamental-guider',
-  storageBucket: 'internet-fundamental-guider.firebasestorage.app',
-  messagingSenderId: '1053498918039',
-  appId: '1:1053498918039:web:54f2d56dc345f0a1b995d2',
-  measurementId: 'G-BKF4Y7CNS9'
+  apiKey: process.env.FIREBASE_API_KEY,
+  authDomain: process.env.FIREBASE_AUTH_DOMAIN,
+  projectId: process.env.FIREBASE_PROJECT_ID,
+  storageBucket: process.env.FIREBASE_STORAGE_BUCKET,
+  messagingSenderId: process.env.FIREBASE_MESSAGING_SENDER_ID,
+  appId: process.env.FIREBASE_APP_ID,
+  measurementId: process.env.FIREBASE_MEASUREMENT_ID,
 };
 
 export const app = initializeApp(firebaseConfig);

--- a/src/modules/segmentation.ts
+++ b/src/modules/segmentation.ts
@@ -1,6 +1,6 @@
 import { FilesetResolver, ImageSegmenter, ImageSegmenterResult } from '@mediapipe/tasks-vision';
 
-const ROBOFLOW_API_KEY = 'rf_wTNbY7mGHVVON6FGybQgsKPfmkP2';
+const ROBOFLOW_API_KEY = process.env.ROBOFLOW_API_KEY;
 const MODEL_URL = `https://storage.googleapis.com/mediapipe-models/image_segmenter/deeplab_v3/float32/1/deeplab_v3.tflite?api_key=${ROBOFLOW_API_KEY}`;
 
 export class LegoSegmenter {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,12 @@
 const path = require('path');
+const webpack = require('webpack');
+const dotenv = require('dotenv');
+
+const env = dotenv.config().parsed || {};
+const envKeys = Object.keys(env).reduce((prev, next) => {
+    prev[`process.env.${next}`] = JSON.stringify(env[next]);
+    return prev;
+}, {});
 
 module.exports = {
     mode: 'development',
@@ -31,6 +39,9 @@ module.exports = {
             }
         ]
     },
+    plugins: [
+        new webpack.DefinePlugin(envKeys)
+    ],
     devtool: 'source-map',
     devServer: {
         static: {


### PR DESCRIPTION
## Summary
- inject environment variables from `.env` with `dotenv`
- read Firebase config from `process.env` in `firebase.ts`
- read Roboflow API key from `process.env` in `segmentation.ts`
- provide `.env.example` and document setup steps
- ignore local `.env` files

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685965c8c004833092e047ee87657130