### PR TITLE
Handle camera and model initialization errors

### DIFF
--- a/src/modules/camera.ts
+++ b/src/modules/camera.ts
@@ -1,10 +1,20 @@
+import { showMessage } from '@modules/ui';
+
 export class Camera {
   constructor(private video: HTMLVideoElement) {}
 
   async start(): Promise<void> {
-    const stream = await navigator.mediaDevices.getUserMedia({ video: { facingMode: 'environment' }, audio: false });
-    this.video.srcObject = stream;
-    await this.video.play();
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({
+        video: { facingMode: 'environment' },
+        audio: false,
+      });
+      this.video.srcObject = stream;
+      await this.video.play();
+    } catch (err) {
+      showMessage('Camera permission denied');
+      throw err;
+    }
   }
 
   capture(target: HTMLCanvasElement): CanvasRenderingContext2D {

--- a/src/modules/segmentation.ts
+++ b/src/modules/segmentation.ts
@@ -1,4 +1,5 @@
 import { FilesetResolver, ImageSegmenter, ImageSegmenterResult } from '@mediapipe/tasks-vision';
+import { showMessage } from '@modules/ui';
 
 const ROBOFLOW_API_KEY = 'rf_wTNbY7mGHVVON6FGybQgsKPfmkP2';
 const MODEL_URL = `https://storage.googleapis.com/mediapipe-models/image_segmenter/deeplab_v3/float32/1/deeplab_v3.tflite?api_key=${ROBOFLOW_API_KEY}`;
@@ -7,10 +8,18 @@ export class LegoSegmenter {
   private segmenter?: ImageSegmenter;
 
   async init() {
-    const vision = await FilesetResolver.forVisionTasks(
-      'https://cdn.jsdelivr.net/npm/@mediapipe/tasks-vision/wasm'
-    );
-    this.segmenter = await ImageSegmenter.createFromModelPath(vision, MODEL_URL);
+    try {
+      const vision = await FilesetResolver.forVisionTasks(
+        'https://cdn.jsdelivr.net/npm/@mediapipe/tasks-vision/wasm'
+      );
+      this.segmenter = await ImageSegmenter.createFromModelPath(
+        vision,
+        MODEL_URL
+      );
+    } catch (err) {
+      showMessage('Failed to load segmentation model');
+      throw err;
+    }
   }
 
   async segment(image: HTMLCanvasElement): Promise<ImageSegmenterResult | null> {


### PR DESCRIPTION
## Summary
- handle camera permissions failure via `showMessage`
- handle image segmenter model init errors

## Testing
- `npm run tsc:build` *(fails: Cannot find module)*

------
https://chatgpt.com/codex/tasks/task_e_68596ea2c1f0833084172be60115ffc9