### PR TITLE
Handle segmentation failures

### DIFF
--- a/src/modules/segmentation.ts
+++ b/src/modules/segmentation.ts
@@ -1,5 +1,5 @@
 // src/segmentation.ts
-import { FilesetResolver, ImageSegmenter, ImageSegmenterResult } from '@mediapipe/tasks-vision';
+import { FilesetResolver, ImageSegmenter } from '@mediapipe/tasks-vision';
 import { showMessage } from '@modules/ui';
 
 const ROBOFLOW_API_KEY = process.env.ROBOFLOW_API_KEY;
@@ -30,6 +30,7 @@ export class LegoSegmenter {
 
   async segment(image: HTMLCanvasElement): Promise<any | null> {
     if (!this.segmenter) return null;
+
     const result = this.segmenter.segment(image);
     if (!result || !result.categoryMask) {
       console.warn('Segmentation returned no valid category mask');
@@ -41,7 +42,9 @@ export class LegoSegmenter {
     const hasForeground = maskData.some((v: number) => v > 0);
     if (!hasForeground) {
       console.warn('Segmentation mask contains only background pixels');
+      return null;
     }
+
     return result;
   }
 }

--- a/src/modules/vision.ts
+++ b/src/modules/vision.ts
@@ -2,7 +2,7 @@
 import { Camera } from '@modules/camera';
 import { LegoSegmenter } from '@modules/segmentation';
 import { BoardRectifier } from '@modules/rectify';
-import { showLoadingIndicator } from '@modules/ui';
+import { showLoadingIndicator, showMessage } from '@modules/ui';
 import { prominent } from 'color.js';
 
 export class VisionApp {
@@ -74,6 +74,10 @@ export class VisionApp {
 
       // 3. 运行分割模型
       const result = await this.segmenter.segment(canvasForSeg);
+      if (!result) {
+        showMessage('无法检测到前景，请将乐高底板放入画面中心');
+        return;
+      }
       console.log('Segmentation result:', result);
 
       // 4. 单通道掩码 → RGBA ImageData
@@ -118,7 +122,8 @@ export class VisionApp {
       // 7. 主色提取
       const dataUrl = clippedCanvas.toDataURL();
       if (dataUrl === 'data:,') {
-        throw new Error('生成的 Data URL 无效，可能是空白图像');
+        showMessage('裁剪后的 Canvas 内容为空，无法提取颜色');
+        return;
       }
       const rawColors = await prominent(dataUrl, { amount: 1 });
       const [r, g, b] = Array.isArray(rawColors[0])


### PR DESCRIPTION
## Summary
- handle cases where segmentation mask has no foreground
- inform the user if color extraction cannot proceed

## Testing
- `npm run tsc:build`

------
https://chatgpt.com/codex/tasks/task_e_6862a5ff87248330acee2524f0664067