### PR TITLE
Implement teacher stats and quiz editor

### DIFF
--- a/public/quiz_editor.html
+++ b/public/quiz_editor.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="zh">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>题库编辑</title>
+</head>
+<body>
+<header class="topbar">
+  <div class="logo">乐高网络分析器</div>
+  <nav class="main-nav"><a href="/">首页</a></nav>
+  <button id="logoutBtn" class="btn-primary">登出</button>
+</header>
+<main class="main-content">
+  <h2>题库编辑</h2>
+  <label>选择周次:
+    <select id="weekSelect">
+      <option value="1">1</option>
+      <option value="2">2</option>
+      <option value="3">3</option>
+      <option value="4">4</option>
+      <option value="5">5</option>
+      <option value="6">6</option>
+      <option value="7">7</option>
+      <option value="8">8</option>
+      <option value="9">9</option>
+      <option value="10">10</option>
+    </select>
+  </label>
+  <ul id="questionList"></ul>
+  <form id="questionForm">
+    <textarea id="promptInput" placeholder="题目" required></textarea>
+    <input type="text" class="option-input" placeholder="选项 A" required />
+    <input type="text" class="option-input" placeholder="选项 B" required />
+    <input type="text" class="option-input" placeholder="选项 C" required />
+    <input type="text" class="option-input" placeholder="选项 D" required />
+    <label>正确选项:
+      <select id="correctIndex">
+        <option value="0">A</option>
+        <option value="1">B</option>
+        <option value="2">C</option>
+        <option value="3">D</option>
+      </select>
+    </label>
+    <button type="submit" class="btn-primary">添加</button>
+  </form>
+</main>
+<script src="/quiz_editor.bundle.js" defer></script>
+</body>
+</html>

--- a/public/teacher_record.html
+++ b/public/teacher_record.html
@@ -1,16 +1,20 @@
 <!DOCTYPE html>
 <html lang="zh">
 <head>
-    <meta charset="UTF-8" /><meta name="viewport" content="width=device-width,initial-scale=1" />
-    <title>学习记录 | 教师</title>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>学习记录 | 教师</title>
 </head>
 <body>
 <header class="topbar">
-    <div class="logo">乐高网络分析器</div>
-    <nav class="main-nav"><a href="/">首页</a></nav>
+  <div class="logo">乐高网络分析器</div>
+  <nav class="main-nav"><a href="/">首页</a></nav>
+  <button id="logoutBtn" class="btn-primary">登出</button>
 </header>
 <main class="main-content">
-    <h2>教师端页面开发中…</h2>
+  <h2>学生测验统计</h2>
+  <canvas id="scoreChart" width="400" height="200"></canvas>
+  <canvas id="timeChart" width="400" height="200"></canvas>
 </main>
 <script src="/teacher_record.bundle.js" defer></script>
 </body>

--- a/src/index.ts
+++ b/src/index.ts
@@ -96,7 +96,12 @@ window.addEventListener('DOMContentLoaded', async () => {
       recordBtn.onclick = async e => {
         e.preventDefault();
         const snap = await getDoc(doc(db, 'users', user.uid));
-        const role = snap.exists() ? snap.data().role : 'student';
+        let role = 'student';
+        if (snap.exists()) {
+          role = snap.data().role;
+        } else if (user.email === 'steve.kerrison@jcu.edu.au') {
+          role = 'teacher';
+        }
         window.location.href = role === 'teacher'
             ? '/teacher_record.html'
             : '/student_record.html';

--- a/src/quiz_editor.ts
+++ b/src/quiz_editor.ts
@@ -1,0 +1,60 @@
+import './styles.css';
+import { auth, db } from '@modules/firebase';
+import { onAuthStateChanged, signOut, User } from 'firebase/auth';
+import { collection, query, where, getDocs, addDoc, deleteDoc, doc } from 'firebase/firestore';
+
+const TEACHER_EMAIL = 'steve.kerrison@jcu.edu.au';
+
+document.addEventListener('DOMContentLoaded', () => {
+  const weekSelect  = document.getElementById('weekSelect') as HTMLSelectElement;
+  const form        = document.getElementById('questionForm') as HTMLFormElement;
+  const logoutBtn   = document.getElementById('logoutBtn') as HTMLButtonElement | null;
+  const list        = document.getElementById('questionList') as HTMLElement;
+
+  // 加载当前周题目
+  async function load() {
+    const week = parseInt(weekSelect.value, 10);
+    const snap = await getDocs(query(collection(db, 'questions'), where('week','==',week)));
+    list.innerHTML = '';
+    snap.docs.forEach((ds: any) => {
+      const d = ds.data() as any;
+      const li = document.createElement('li');
+      li.textContent = `${d.id}. ${d.prompt}`;
+      const del = document.createElement('button');
+      del.textContent = '删除';
+      del.onclick = async () => {
+        await deleteDoc(doc(db, 'questions', ds.id));
+        await load();
+      };
+      li.appendChild(del);
+      list.appendChild(li);
+    });
+  }
+
+  // @ts-ignore
+  onAuthStateChanged(auth, async (user: User | null) => {
+    if (!user) return (window.location.href = '/login.html');
+    if (user.email !== TEACHER_EMAIL) {
+      window.location.href = '/';
+      return;
+    }
+    await load();
+    logoutBtn && (logoutBtn.onclick = async () => { await signOut(auth); window.location.href = '/login.html'; });
+  });
+
+  weekSelect.onchange = load;
+
+  form.addEventListener('submit', async e => {
+    e.preventDefault();
+    const week = parseInt(weekSelect.value, 10);
+    const prompt = (document.getElementById('promptInput') as HTMLInputElement).value.trim();
+    const opts = Array.from(document.querySelectorAll<HTMLInputElement>('.option-input')).map(i => i.value.trim());
+    const correctIndex = parseInt((document.getElementById('correctIndex') as HTMLSelectElement).value, 10);
+    if (!prompt || opts.some(o => !o)) return alert('请完整填写题目和选项');
+    const snap = await getDocs(query(collection(db, 'questions'), where('week','==',week)));
+    const id = snap.size + 1;
+    await addDoc(collection(db, 'questions'), { week, id, prompt, options: opts, correctIndex });
+    form.reset();
+    await load();
+  });
+});

--- a/src/teacher_record.ts
+++ b/src/teacher_record.ts
@@ -1,0 +1,58 @@
+import './styles.css';
+import { auth, db } from '@modules/firebase';
+import { onAuthStateChanged, signOut, User } from 'firebase/auth';
+import { collectionGroup, getDocs } from 'firebase/firestore';
+// @ts-ignore
+import Chart from 'chart.js/auto';
+
+const TEACHER_EMAIL = 'steve.kerrison@jcu.edu.au';
+
+document.addEventListener('DOMContentLoaded', () => {
+  const logoutBtn = document.getElementById('logoutBtn') as HTMLButtonElement | null;
+
+  // @ts-ignore
+  onAuthStateChanged(auth, async (user: User | null) => {
+    if (!user) return (window.location.href = '/login.html');
+
+    if (logoutBtn) {
+      logoutBtn.onclick = async () => {
+        await signOut(auth);
+        window.location.href = '/login.html';
+      };
+    }
+
+    if (user.email !== TEACHER_EMAIL) {
+      window.location.href = '/student_record.html';
+      return;
+    }
+
+    // 获取所有学生的测验记录
+    const snap = await getDocs(collectionGroup(db, 'quizAttempts'));
+    const data = snap.docs.map((d: any) => d.data() as any);
+
+    const byWeek: Record<number, any[]> = {};
+    data.forEach((rec: any) => {
+      byWeek[rec.week] ??= [];
+      byWeek[rec.week].push(rec);
+    });
+
+    const weeks = Array.from({ length: 10 }, (_, i) => i + 1);
+    const avgScore = weeks.map(w => {
+      const arr = byWeek[w] || [];
+      return arr.length ? arr.reduce((s, r) => s + r.correctCnt, 0) / arr.length : 0;
+    });
+    const avgTime = weeks.map(w => {
+      const arr = byWeek[w] || [];
+      return arr.length ? Math.round(arr.reduce((s, r) => s + r.totalTime, 0) / arr.length) : 0;
+    });
+
+    new Chart(
+      document.getElementById('scoreChart') as HTMLCanvasElement,
+      { type: 'bar', data: { labels: weeks.map(String), datasets: [{ label: '平均得分', data: avgScore }] } }
+    );
+    new Chart(
+      document.getElementById('timeChart') as HTMLCanvasElement,
+      { type: 'bar', data: { labels: weeks.map(String), datasets: [{ label: '平均耗时(s)', data: avgTime }] } }
+    );
+  });
+});

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -146,7 +146,8 @@ module.exports = {
         login:           './src/login.ts',
         register:        './src/register.ts',
         student_record:  './src/student_record.ts',
-        teacher_record:  './src/teacher_record.ts'
+        teacher_record:  './src/teacher_record.ts',
+        quiz_editor:     './src/quiz_editor.ts'
     },
     output: {
         filename:   '[name].bundle.js',


### PR DESCRIPTION
## Summary
- add teacher record page with charts
- implement Firestore stats logic for teachers
- basic quiz editor page for teacher use
- route role via index.ts and update webpack config

## Testing
- `npm run tsc:build`
- `npm run build` *(fails: Failed to load ./.env; copy-bundle.js missing bundle)*

------
https://chatgpt.com/codex/tasks/task_e_686400a005d483309ab4fae3e86e9a97