### PR TITLE
Use firestore role to check teacher pages

### DIFF
--- a/src/quiz_editor.ts
+++ b/src/quiz_editor.ts
@@ -1,9 +1,8 @@
 import './styles.css';
 import { auth, db } from '@modules/firebase';
 import { onAuthStateChanged, signOut, User } from 'firebase/auth';
-import { collection, query, where, getDocs, addDoc, deleteDoc, doc } from 'firebase/firestore';
+import { collection, query, where, getDocs, addDoc, deleteDoc, doc, getDoc } from 'firebase/firestore';
 
-const TEACHER_EMAIL = 'steve.kerrison@jcu.edu.au';
 
 document.addEventListener('DOMContentLoaded', () => {
   const weekSelect  = document.getElementById('weekSelect') as HTMLSelectElement;
@@ -34,7 +33,9 @@ document.addEventListener('DOMContentLoaded', () => {
   // @ts-ignore
   onAuthStateChanged(auth, async (user: User | null) => {
     if (!user) return (window.location.href = '/login.html');
-    if (user.email !== TEACHER_EMAIL) {
+    const snapDoc = await getDoc(doc(db, 'users', user.uid));
+    const role = snapDoc.exists() ? (snapDoc.data() as any).role : undefined;
+    if (role !== 'teacher' && user.email !== 'steve.kerrison@jcu.edu.au') {
       window.location.href = '/';
       return;
     }

--- a/src/teacher_record.ts
+++ b/src/teacher_record.ts
@@ -1,11 +1,10 @@
 import './styles.css';
 import { auth, db } from '@modules/firebase';
 import { onAuthStateChanged, signOut, User } from 'firebase/auth';
-import { collectionGroup, getDocs } from 'firebase/firestore';
+import { collectionGroup, getDocs, doc, getDoc } from 'firebase/firestore';
 // @ts-ignore
 import Chart from 'chart.js/auto';
 
-const TEACHER_EMAIL = 'steve.kerrison@jcu.edu.au';
 
 document.addEventListener('DOMContentLoaded', () => {
   const logoutBtn = document.getElementById('logoutBtn') as HTMLButtonElement | null;
@@ -21,7 +20,9 @@ document.addEventListener('DOMContentLoaded', () => {
       };
     }
 
-    if (user.email !== TEACHER_EMAIL) {
+    const snapDoc = await getDoc(doc(db, 'users', user.uid));
+    const role = snapDoc.exists() ? (snapDoc.data() as any).role : undefined;
+    if (role !== 'teacher' && user.email !== 'steve.kerrison@jcu.edu.au') {
       window.location.href = '/student_record.html';
       return;
     }


### PR DESCRIPTION
## Summary
- update `teacher_record.ts` and `quiz_editor.ts` to look up the user's role from Firestore
- fall back to the old email check if the role isn't teacher

## Testing
- `npm run build` *(fails: ENOENT copyfile '/workspace/project/dist/bundle.js' -> '/workspace/project/public/bundle.js')*

------
https://chatgpt.com/codex/tasks/task_e_68664bc44bec8330bb0eaae0e63a1723