### PR TITLE
Fix TypeScript build for OpenCV usage

### DIFF
--- a/src/custom.d.ts
+++ b/src/custom.d.ts
@@ -4,7 +4,10 @@ declare module 'firebase/app';
 declare module 'firebase/auth';
 declare module 'firebase/firestore';
 declare module 'firebase/analytics';
-declare module 'quantize';
+declare module 'quantize' {
+  const quantize: any;
+  export default quantize;
+}
 declare module 'color.js';
 declare module 'colorjs.io';
 declare module 'colorjs.io/src/deltaE.js';
@@ -12,12 +15,10 @@ declare module '@techstark/opencv-js' {
   const cv: any;
   export default cv;
 }
-declare global {
-  namespace cv {
-    // 以后在签名里写 cv.Mat，TS 就认这是 any
-    type Mat       = any;
-    type MatVector = any;
-  }
+declare namespace cv {
+  // 以后在签名里写 cv.Mat，TS 就认这是 any
+  type Mat       = any;
+  type MatVector = any;
 }
 
 

--- a/src/modules/legoPipeline.ts
+++ b/src/modules/legoPipeline.ts
@@ -159,22 +159,37 @@ export class LegoPipeline {
 
   private thresholdLab(labMat: cv.Mat, lab: [number, number, number]): cv.Mat {
     const [L, A, B] = lab;
-    // 计算上下界
-    const lowScalar = new cv.Scalar(
-        Math.max(0, L - 10),
-        Math.max(0, A - 15),
-        Math.max(0, B - 15),
-        0          // 必须给第四个分量
+
+    // 使用 Mat 表示阈值，以避免 Emscripten 绑定将 Scalar 当成 Mat 处理
+    const lower = new cv.Mat(
+        labMat.rows,
+        labMat.cols,
+        labMat.type(),
+        new cv.Scalar(
+            Math.max(0, L - 10),
+            Math.max(0, A - 15),
+            Math.max(0, B - 15),
+            0
+        )
     );
-    const highScalar = new cv.Scalar(
-        Math.min(255, L + 10),
-        Math.min(255, A + 15),
-        Math.min(255, B + 15),
-        255        // 必须给第四个分量
+    const upper = new cv.Mat(
+        labMat.rows,
+        labMat.cols,
+        labMat.type(),
+        new cv.Scalar(
+            Math.min(255, L + 10),
+            Math.min(255, A + 15),
+            Math.min(255, B + 15),
+            255
+        )
     );
 
     const mask = new cv.Mat();
-    cv.inRange(labMat, lowScalar, highScalar, mask);
+    cv.inRange(labMat, lower, upper, mask);
+
+    lower.delete();
+    upper.delete();
+
     return mask;
   }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,6 @@
       "@modules/*": ["modules/*"]
     }
   },
-  "include": ["src/**/*", "custom.d.ts"],
+  "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
## Summary
- define OpenCV threshold bounds using `cv.Mat` to avoid runtime binding errors

## Testing
- `npm run tsc:build`


------
https://chatgpt.com/codex/tasks/task_e_687b3b3608888330b4906031d2a91213