### PR TITLE
Add segmented block images on result page

### DIFF
--- a/public/lego-result.html
+++ b/public/lego-result.html
@@ -14,6 +14,7 @@
     <img id="legoImage" alt="LEGO result" />
     <canvas id="resultOverlay" class="overlay-canvas"></canvas>
   </div>
+  <div id="block-list" class="blocks"></div>
 </main>
 <script src="/lego-result.bundle.js"></script>
 </body>

--- a/src/legoResult.ts
+++ b/src/legoResult.ts
@@ -26,6 +26,18 @@ window.addEventListener('DOMContentLoaded', () => {
     console.warn('【结果页】未找到 legoResultBlocks');
   }
 
+  // 读取裁剪后的积木图片
+  const rawBlockImages = sessionStorage.getItem('legoResultBlockImages');
+  let blockImages: string[] = [];
+  if (rawBlockImages) {
+    try {
+      blockImages = JSON.parse(rawBlockImages);
+      console.log('【结果页】blockImages 数量：', blockImages.length);
+    } catch (e) {
+      console.error('【结果页】解析 blockImages 出错：', e);
+    }
+  }
+
   function draw() {
     if (!img || !overlay) return;
     overlay.width = img.naturalWidth;
@@ -44,6 +56,16 @@ window.addEventListener('DOMContentLoaded', () => {
   if (img) {
     if (img.complete) draw();
     else img.addEventListener('load', draw);
+  }
+
+  // 在页面上展示裁剪后的图片
+  const blockList = document.getElementById('block-list') as HTMLDivElement | null;
+  if (blockList) {
+    blockImages.forEach(src => {
+      const i = document.createElement('img');
+      i.src = src;
+      blockList.appendChild(i);
+    });
   }
 
   // 3. 绑定返回按钮

--- a/src/modules/vision.ts
+++ b/src/modules/vision.ts
@@ -44,9 +44,24 @@ export class VisionApp {
     ctx.drawImage(this.overlay, 0, 0);
     const image = out.toDataURL('image/png');
 
+    // 裁剪每个识别块生成 Base64
+    const blockImages: string[] = [];
+    for (const b of blocks) {
+      const c = document.createElement('canvas');
+      c.width = b.width;
+      c.height = b.height;
+      const bctx = c.getContext('2d')!;
+      bctx.drawImage(this.capture, b.x, b.y, b.width, b.height, 0, 0, b.width, b.height);
+      blockImages.push(c.toDataURL('image/png'));
+    }
+
     // **在这里打印**，方便调试看是不是拿到了数据
     console.log('导出的 image 长度：', image.length);
     console.log('识别到的 blocks:', blocks);
+    console.log('裁剪得到的 blockImages 数量：', blockImages.length);
+
+    sessionStorage.setItem('legoResultBlocks', JSON.stringify(blocks));
+    sessionStorage.setItem('legoResultBlockImages', JSON.stringify(blockImages));
 
     // 3) 返回给调用方
     return { image, blocks };

--- a/src/styles.css
+++ b/src/styles.css
@@ -641,3 +641,19 @@ a:hover {
   background: #000;
   overflow: hidden;
 }
+
+/* 展示分割后图片的列表 */
+#block-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(80px, 1fr));
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+#block-list img {
+  width: 100%;
+  height: auto;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  background: var(--color-surface);
+  box-shadow: var(--shadow-sm);
+}


### PR DESCRIPTION
## Summary
- crop each Lego block to Base64 images in `analyzeAndExport`
- save cropped block images in session storage
- read these images on the result page and display them
- add container in result HTML and styling for grid layout

## Testing
- `npm run build`
- `npm start` (terminated after startup)

------
https://chatgpt.com/codex/tasks/task_e_687b54e92cb8833094957684dc21e0ec