### PR TITLE
Implement protocol-component color mapping

### DIFF
--- a/colorMap.json
+++ b/colorMap.json
@@ -1,0 +1,20 @@
+{
+  "TCP": {
+    "Header":   "Red",
+    "Payload":  "Green",
+    "Checksum": "Yellow"
+  },
+  "UDP": {
+    "Header":  "Orange",
+    "Payload": "Blue"
+  },
+  "OSI": {
+    "应用层":     "White",
+    "表示层":     "Purple",
+    "会话层":     "Blue",
+    "传输层":     "DarkBlue",
+    "网络层":     "Yellow",
+    "数据链路层": "Green",
+    "物理层":     "Black"
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 // src/index.ts
 import { VisionApp } from '@modules/vision';
+import { loadColorMap } from '@modules/colorMap';
 import './styles.css';
 import { bindButton, showMessage, showProcessingSpinner } from '@modules/ui';
 
@@ -16,6 +17,7 @@ window.addEventListener('DOMContentLoaded', async () => {
   const DEBUG = true;
 
   try {
+    await loadColorMap();
     await app.start();
     showMessage('Camera ready. Click capture to analyze.');
   } catch (error) {

--- a/src/modules/colorMap.ts
+++ b/src/modules/colorMap.ts
@@ -1,0 +1,25 @@
+export type ProtocolMap = Record<string, Record<string, string>>;
+
+export let colorToProtoComp: Record<string, { protocol: string; component: string }> = {};
+
+export async function loadColorMap(): Promise<void> {
+  try {
+    const resp = await fetch('/colorMap.json');
+    if (!resp.ok) {
+      console.error('Failed to load colorMap.json:', resp.status);
+      return;
+    }
+    const map: ProtocolMap = await resp.json();
+    const table: typeof colorToProtoComp = {};
+    for (const protocol in map) {
+      const comps = map[protocol];
+      for (const component in comps) {
+        const color = comps[component];
+        table[color] = { protocol, component };
+      }
+    }
+    colorToProtoComp = table;
+  } catch (err) {
+    console.error('Error loading colorMap.json', err);
+  }
+}

--- a/src/modules/legoBoardAnalyzer.ts
+++ b/src/modules/legoBoardAnalyzer.ts
@@ -4,6 +4,7 @@ import cv from '@techstark/opencv-js';
 import Color from 'colorjs.io';
 import { LegoSegmenter } from '@modules/segmentation';
 import { legoColors, LegoColor } from '@modules/legoColors';
+import { colorToProtoComp } from '@modules/colorMap';
 
 /** Result of color detection for a single grid cell */
 export interface CellColorResult {
@@ -13,6 +14,10 @@ export interface CellColorResult {
   col: number;
   /** Detected LEGO color name */
   color: string;
+  /** Protocol this color represents */
+  protocol: string;
+  /** Component name within the protocol */
+  component: string;
   /** Four corner points of the cell on the original image */
   quad: Array<{ x: number; y: number }>;
 }
@@ -227,7 +232,15 @@ export class LegoBoardAnalyzer {
 
         // Map valid cell back to original coordinates
         const quad = this.mapCellQuad(x, y, w, h, MInv);
-        results.push({ row: r, col: c, color: name, quad });
+        const mapped = colorToProtoComp[name] || { protocol: '', component: '' };
+        results.push({
+          row: r,
+          col: c,
+          color: name,
+          protocol: mapped.protocol,
+          component: mapped.component,
+          quad,
+        });
       }
     }
     console.log('[LBA] 检测结束，结果数量 =', results.length);


### PR DESCRIPTION
## Summary
- maintain color mappings in `colorMap.json`
- load mappings on startup via new `colorMap` module
- include protocol/component info in `CellColorResult`
- map detected colors to protocol components in `LegoBoardAnalyzer`
- group and label overlay drawing by protocol and component

## Testing
- `npm run tsc:build`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6885fecb3e008330a4ca61bbd379a177