### PR TITLE
refactor: centralize canvas drawing in VisionApp

### DIFF
--- a/src/modules/legoBoardAnalyzer.ts
+++ b/src/modules/legoBoardAnalyzer.ts
@@ -39,8 +39,7 @@ export class LegoBoardAnalyzer {
 
   /**
    * Analyze the provided canvas and return detected colors for
-   * each grid cell. The original canvas will be annotated with
-   * cell outlines and color labels.
+   * each grid cell. No drawing is performed.
    */
   async analyze(canvas: HTMLCanvasElement): Promise<CellColorResult[]> {
     console.log('[LBA] 🚀 analyze() start', {
@@ -250,13 +249,8 @@ export class LegoBoardAnalyzer {
     M.delete();
     MInv.delete();
 
-    // 5) Draw results back onto original canvas
-    this.drawResults(canvas, results);
-    console.log('[LBA] drawResults 完成');
-
     return results;
   }
-
   /**
    * Convert approx contour to ordered quad [tl,tr,br,bl]
    */
@@ -302,35 +296,12 @@ export class LegoBoardAnalyzer {
     return quad;
   }
 
-  /** Draw polygons and color labels on the canvas */
-  private drawResults(canvas: HTMLCanvasElement, cells: CellColorResult[]): void {
-    const ctx = canvas.getContext('2d')!;
-    ctx.lineWidth = 1;
-    ctx.font = '10px sans-serif';
-    ctx.textBaseline = 'top';
-
-    cells.forEach(cell => {
-      ctx.beginPath();
-      ctx.moveTo(cell.quad[0].x, cell.quad[0].y);
-      for (let i = 1; i < 4; i++) {
-        ctx.lineTo(cell.quad[i].x, cell.quad[i].y);
-      }
-      ctx.closePath();
-      ctx.strokeStyle = '#ff0000';
-      ctx.stroke();
-
-      // Draw color label at first corner
-      ctx.fillStyle = '#ff0000';
-      ctx.fillText(cell.color, cell.quad[0].x, cell.quad[0].y);
-    });
-  }
-
   /**
    * Match a Lab color (OpenCV range 0-255) to the closest LEGO color and
    * return the deltaE distance. This is used for filtering out background
    * or poorly detected bricks.
    */
-  private matchColorWithDE(lab: [number, number, number]): {
+  private matchColorWithDE(lab: [number, number, number]): { 
     name: string; deltaE: number;
   } {
     // Convert from OpenCV Lab (0-255) to standard Lab range.

--- a/src/modules/vision.ts
+++ b/src/modules/vision.ts
@@ -59,12 +59,29 @@ export class VisionApp {
     ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
     ctx.clearRect(0, 0, dispW, dispH);
 
-    // 2) 颜色映射
+    // 2) 绘制单个格子轮廓和颜色标签
+    ctx.lineWidth = 1;
+    ctx.font = '10px sans-serif';
+    ctx.textBaseline = 'top';
+    ctx.strokeStyle = '#ff0000';
+    ctx.fillStyle = '#ff0000';
+    for (const cell of cells) {
+      ctx.beginPath();
+      ctx.moveTo(cell.quad[0].x, cell.quad[0].y);
+      for (let i = 1; i < 4; i++) {
+        ctx.lineTo(cell.quad[i].x, cell.quad[i].y);
+      }
+      ctx.closePath();
+      ctx.stroke();
+      ctx.fillText(cell.color, cell.quad[0].x, cell.quad[0].y);
+    }
+
+    // 3) 颜色映射
     const colorMap = new Map<string, string>(
         legoColors.map(c => [c.name, `rgb(${c.rgb[0]}, ${c.rgb[1]}, ${c.rgb[2]})`])
     );
 
-    // 3) 按 protocol+component + row 分组
+    // 4) 按 protocol+component + row 分组
     const grouped = new Map<string, Map<number, CellColorResult[]>>();
     for (const cell of cells) {
       const label = `${cell.protocol} · ${cell.component}`;
@@ -78,7 +95,7 @@ export class VisionApp {
       byRow.set(cell.row, rowList);
     }
 
-    // 4) 绘制各组凸包
+    // 5) 绘制各组凸包
     ctx.lineWidth = 2;
     ctx.font = '12px sans-serif';
     ctx.fillStyle = '#fff';


### PR DESCRIPTION
## Summary
- Stop `LegoBoardAnalyzer` from drawing on the canvas; it now only returns `CellColorResult[]`
- Move canvas drawing into `VisionApp.draw`, which renders cell outlines, labels, and grouped hulls

## Testing
- `npm test` (fails: Missing script "test")
- `npm run tsc:build`


------
https://chatgpt.com/codex/tasks/task_e_688dd8b4c0c48330aaf06a2f7197574a