### PR TITLE
Add module tests

### DIFF
--- a/server/__tests__/segmentService.test.ts
+++ b/server/__tests__/segmentService.test.ts
@@ -1,0 +1,11 @@
+/**
+ * @jest-environment node
+ */
+
+describe('segmentService module', () => {
+  test('loads without crashing when API key present', () => {
+    process.env.ROBOFLOW_API_KEY = 'test';
+    expect(() => require('../src/segmentService')).not.toThrow();
+  });
+});
+

--- a/server/src/segmentService.ts
+++ b/server/src/segmentService.ts
@@ -13,11 +13,11 @@ dotenv.config({
 const ROBOFLOW_API_KEY = process.env.ROBOFLOW_API_KEY;
 if (!ROBOFLOW_API_KEY) {
   console.error('Missing ROBOFLOW_API_KEY in .env');
-  process.exit(1);
+  (process as any).exit(1);
 }
 console.log('Loaded ROBOFLOW_API_KEY =', ROBOFLOW_API_KEY);
 
-const app = express();
+export const app = express();
 app.use(cors());
 app.use(express.json({ limit: '20mb' }));
 
@@ -67,7 +67,9 @@ app.post('/api/segment', async (req, res) => {
   }
 });
 
-const port = process.env.PORT || 3000;
-app.listen(port, () => {
-  console.log(`Segment service listening on port ${port}`);
-});
+if (require.main === module) {
+  const port = process.env.PORT || 3000;
+  app.listen(port, () => {
+    console.log(`Segment service listening on port ${port}`);
+  });
+}

--- a/src/modules/__tests__/camera.test.ts
+++ b/src/modules/__tests__/camera.test.ts
@@ -1,0 +1,46 @@
+import { Camera } from '@modules/camera';
+import { showMessage } from '@modules/ui';
+
+jest.mock('@modules/ui', () => ({ showMessage: jest.fn() }));
+
+describe('camera module', () => {
+  let video: HTMLVideoElement;
+
+  beforeEach(() => {
+    video = document.createElement('video');
+    (navigator as any).mediaDevices = {
+      getUserMedia: jest.fn().mockResolvedValue('stream'),
+    };
+    (video as any).play = jest.fn().mockResolvedValue(undefined);
+  });
+
+  test('start sets srcObject and plays video', async () => {
+    const camera = new Camera(video);
+    await camera.start();
+    expect(navigator.mediaDevices.getUserMedia).toHaveBeenCalled();
+    expect(video.srcObject).toBe('stream' as any);
+    expect(video.play).toHaveBeenCalled();
+  });
+
+  test('start shows message on error', async () => {
+    (navigator.mediaDevices.getUserMedia as jest.Mock).mockRejectedValue(new Error('err'));
+    const camera = new Camera(video);
+    await expect(camera.start()).rejects.toThrow('err');
+    expect(showMessage).toHaveBeenCalledWith('Camera permission denied');
+  });
+
+  test('capture copies frame to canvas', () => {
+    Object.defineProperty(video, 'videoWidth', { value: 640, configurable: true });
+    Object.defineProperty(video, 'videoHeight', { value: 480, configurable: true });
+    const canvas = document.createElement('canvas');
+    const ctx = { drawImage: jest.fn() } as any;
+    (canvas as any).getContext = jest.fn().mockReturnValue(ctx);
+    const camera = new Camera(video);
+    const returned = camera.capture(canvas);
+    expect(canvas.width).toBe(640);
+    expect(canvas.height).toBe(480);
+    expect(ctx.drawImage).toHaveBeenCalledWith(video, 0, 0, 640, 480);
+    expect(returned).toBe(ctx);
+  });
+});
+

--- a/src/modules/__tests__/colorMap.test.ts
+++ b/src/modules/__tests__/colorMap.test.ts
@@ -1,0 +1,22 @@
+import * as cm from '@modules/colorMap';
+
+describe('colorMap module', () => {
+  beforeEach(() => {
+    (global as any).fetch = jest.fn();
+    (cm as any).colorToProtoComp = {};
+  });
+
+  test('loadColorMap populates lookup table', async () => {
+    const mockMap = { proto: { comp: 'Red' } };
+    (global.fetch as jest.Mock).mockResolvedValue({ ok: true, json: async () => mockMap });
+    await cm.loadColorMap();
+    expect(cm.colorToProtoComp['Red']).toEqual({ protocol: 'proto', component: 'comp' });
+  });
+
+  test('loadColorMap handles failed fetch', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({ ok: false, status: 404 });
+    await cm.loadColorMap();
+    expect(cm.colorToProtoComp['Red']).toBeUndefined();
+  });
+});
+

--- a/src/modules/__tests__/legoBoardAnalyzer.test.ts
+++ b/src/modules/__tests__/legoBoardAnalyzer.test.ts
@@ -1,0 +1,55 @@
+import { LegoBoardAnalyzer } from '@modules/legoBoardAnalyzer';
+import { LegoSegmenter } from '@modules/segmentation';
+import Color from 'colorjs.io';
+
+describe('legoBoardAnalyzer module', () => {
+  test('matchColorWithDE finds nearest color', () => {
+    const analyzer = new LegoBoardAnalyzer({} as LegoSegmenter);
+    const c = new Color('srgb', [231/255, 0, 0]);
+    const lab = c.to('lab').coords;
+    const openCvLab: [number, number, number] = [
+      (lab[0] * 255) / 100,
+      lab[1] + 128,
+      lab[2] + 128,
+    ];
+    const result = (analyzer as any).matchColorWithDE(openCvLab);
+    expect(result.name).toBe('Red');
+    expect(result.deltaE).toBeLessThan(1);
+  });
+
+  test('drawWarpedGrid draws lines', () => {
+    const canvas = document.createElement('canvas');
+    const ctx = {
+      save: jest.fn(),
+      beginPath: jest.fn(),
+      moveTo: jest.fn(),
+      lineTo: jest.fn(),
+      stroke: jest.fn(),
+      restore: jest.fn(),
+      lineWidth: 0,
+      strokeStyle: '',
+    } as any;
+    (canvas as any).getContext = jest.fn().mockReturnValue(ctx);
+    LegoBoardAnalyzer.drawWarpedGrid(canvas, 2, 2, 10);
+    expect(ctx.beginPath).toHaveBeenCalled();
+    expect(ctx.stroke).toHaveBeenCalled();
+  });
+
+  test('drawCellQuads draws points', () => {
+    const canvas = document.createElement('canvas');
+    const ctx = {
+      save: jest.fn(),
+      beginPath: jest.fn(),
+      arc: jest.fn(),
+      fill: jest.fn(),
+      restore: jest.fn(),
+      fillStyle: '',
+      strokeStyle: '',
+    } as any;
+    (canvas as any).getContext = jest.fn().mockReturnValue(ctx);
+    LegoBoardAnalyzer.drawCellQuads(canvas, [{ quad: [{ x: 1, y: 2 }] }]);
+    expect(ctx.arc).toHaveBeenCalledWith(1, 2, 2.5, 0, Math.PI * 2);
+    expect(ctx.fill).toHaveBeenCalled();
+  });
+});
+

--- a/src/modules/__tests__/legoColors.test.ts
+++ b/src/modules/__tests__/legoColors.test.ts
@@ -1,0 +1,9 @@
+import { legoColors } from '@modules/legoColors';
+
+describe('legoColors module', () => {
+  test('contains predefined colors', () => {
+    expect(legoColors.some(c => c.name === 'Red')).toBe(true);
+    expect(legoColors.some(c => c.name === 'Blue')).toBe(true);
+  });
+});
+

--- a/src/modules/__tests__/segmentation.test.ts
+++ b/src/modules/__tests__/segmentation.test.ts
@@ -1,0 +1,31 @@
+import { LegoSegmenter } from '@modules/segmentation';
+
+describe('segmentation module', () => {
+  beforeEach(() => {
+    (global as any).fetch = jest.fn();
+  });
+
+  test('segment posts image and returns predictions', async () => {
+    const canvas = document.createElement('canvas');
+    (canvas as any).toDataURL = jest.fn().mockReturnValue('data:image/jpeg;base64,AAA');
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({ predictions: [{ points: [] }] }),
+    });
+    const segmenter = new LegoSegmenter();
+    const preds = await segmenter.segment(canvas);
+    expect(canvas.toDataURL).toHaveBeenCalledWith('image/jpeg', 0.8);
+    expect(global.fetch).toHaveBeenCalledWith('/api/segment', expect.objectContaining({ method: 'POST' }));
+    expect(preds).toEqual([{ points: [] }]);
+  });
+
+  test('segment handles error response', async () => {
+    const canvas = document.createElement('canvas');
+    (canvas as any).toDataURL = jest.fn().mockReturnValue('data:image/jpeg;base64,AAA');
+    (global.fetch as jest.Mock).mockResolvedValue({ ok: false, status: 500, statusText: 'err' });
+    const segmenter = new LegoSegmenter();
+    const result = await segmenter.segment(canvas);
+    expect(result).toBeNull();
+  });
+});
+

--- a/src/modules/__tests__/vision.test.ts
+++ b/src/modules/__tests__/vision.test.ts
@@ -1,0 +1,71 @@
+jest.mock('@modules/camera', () => ({
+  __esModule: true,
+  Camera: jest.fn().mockImplementation(() => ({
+    start: jest.fn().mockResolvedValue(undefined),
+    capture: jest.fn(),
+  })),
+}));
+
+jest.mock('@modules/segmentation', () => ({
+  __esModule: true,
+  LegoSegmenter: jest.fn(),
+}));
+
+jest.mock('@modules/legoBoardAnalyzer', () => ({
+  __esModule: true,
+  LegoBoardAnalyzer: jest.fn().mockImplementation(() => ({
+    analyze: jest.fn().mockResolvedValue([]),
+  })),
+}));
+
+jest.mock('@modules/colorMap', () => ({ __esModule: true, loadColorMap: jest.fn().mockResolvedValue(undefined) }));
+jest.mock('@modules/ui', () => ({ __esModule: true, showLoadingIndicator: jest.fn() }));
+
+import { VisionApp } from '@modules/vision';
+
+describe('vision module', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('start initializes camera and loads color map', async () => {
+    const video = document.createElement('video');
+    Object.defineProperty(video, 'videoWidth', { value: 640, configurable: true });
+    Object.defineProperty(video, 'videoHeight', { value: 480, configurable: true });
+    const capture = document.createElement('canvas');
+    const overlay = document.createElement('canvas');
+    const app = new VisionApp(video, capture, overlay);
+    await app.start();
+    const camInst = (app as any).camera;
+    const { loadColorMap } = require('@modules/colorMap');
+    expect(camInst.start).toHaveBeenCalled();
+    expect(loadColorMap).toHaveBeenCalled();
+    expect(capture.width).toBe(640);
+    expect(capture.height).toBe(480);
+  });
+
+  test('analyze captures frame and returns cells', async () => {
+    const video = document.createElement('video');
+    const capture = document.createElement('canvas');
+    const overlay = document.createElement('canvas');
+    (overlay as any).getContext = jest.fn().mockReturnValue({
+      setTransform: jest.fn(),
+      clearRect: jest.fn(),
+      beginPath: jest.fn(),
+      arc: jest.fn(),
+      fill: jest.fn(),
+      fillStyle: '',
+      strokeStyle: '',
+    });
+    (overlay as any).getBoundingClientRect = () => ({ width: 100, height: 100, top: 0, left: 0, right: 0, bottom: 0 });
+    const app = new VisionApp(video, capture, overlay);
+    const camInst = (app as any).camera;
+    const analyzerInst = (app as any).analyzer;
+    analyzerInst.analyze.mockResolvedValue([{ row: 1, col: 1, color: 'Red', protocol: 'p', component: 'c', quad: [] }]);
+    const cells = await app.analyze();
+    expect(camInst.capture).toHaveBeenCalledWith(capture);
+    expect(analyzerInst.analyze).toHaveBeenCalledWith(capture);
+    expect(cells).toHaveLength(1);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add unit tests for camera, color map, board analyzer, LEGO colors, segmentation, vision, and segment service
- export Express app from segment service for easier testing

## Testing
- `npx jest src/modules/__tests__/camera.test.ts`
- `npx jest src/modules/__tests__/colorMap.test.ts`
- `npx jest src/modules/__tests__/legoBoardAnalyzer.test.ts`
- `npx jest src/modules/__tests__/legoColors.test.ts`
- `npx jest src/modules/__tests__/segmentation.test.ts`
- `npx jest src/modules/__tests__/vision.test.ts`
- `npx jest server/__tests__/segmentService.test.ts`
- `npx jest`


------
https://chatgpt.com/codex/tasks/task_e_688f310292dc83308fc6263b3c5a5a6d