### PR TITLE
test: add coverage for vision modules

### DIFF
--- a/server/src/segmentService.test.ts
+++ b/server/src/segmentService.test.ts
@@ -1,0 +1,32 @@
+/** @jest-environment node */
+import axios from 'axios';
+
+jest.mock('axios', () => ({
+  post: jest.fn(),
+  isAxiosError: () => false
+}));
+
+describe('segmentService', () => {
+  it('returns predictions from axios', async () => {
+    process.env.ROBOFLOW_API_KEY = 'key';
+    const data = { predictions: [{ id: 1 }] };
+    (axios.post as jest.Mock).mockResolvedValue({ data });
+    const { segmentHandler } = require('./segmentService');
+    const req: any = { body: { imageBase64: 'data:abc' } };
+    const json = jest.fn();
+    const res: any = { status: jest.fn().mockReturnValue({ json }), json };
+    await segmentHandler(req, res);
+    expect(axios.post).toHaveBeenCalled();
+    expect(json).toHaveBeenCalledWith(data);
+  });
+
+  it('validates request body', async () => {
+    process.env.ROBOFLOW_API_KEY = 'key';
+    const { segmentHandler } = require('./segmentService');
+    const json = jest.fn();
+    const res: any = { status: jest.fn().mockReturnValue({ json }) };
+    await segmentHandler({ body: {} } as any, res);
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(json).toHaveBeenCalled();
+  });
+});

--- a/server/src/segmentService.ts
+++ b/server/src/segmentService.ts
@@ -1,5 +1,5 @@
 // segmentService.ts
-import express from 'express';
+import express, { Request, Response } from 'express';
 import cors from 'cors';
 import axios from 'axios';
 import dotenv from 'dotenv';
@@ -12,16 +12,11 @@ dotenv.config({
 
 const ROBOFLOW_API_KEY = process.env.ROBOFLOW_API_KEY;
 if (!ROBOFLOW_API_KEY) {
-  console.error('Missing ROBOFLOW_API_KEY in .env');
-  process.exit(1);
+  throw new Error('Missing ROBOFLOW_API_KEY in .env');
 }
 console.log('Loaded ROBOFLOW_API_KEY =', ROBOFLOW_API_KEY);
 
-const app = express();
-app.use(cors());
-app.use(express.json({ limit: '20mb' }));
-
-app.post('/api/segment', async (req, res) => {
+export const segmentHandler = async (req: Request, res: Response) => {
   const { imageBase64 } = req.body;
   if (!imageBase64 || typeof imageBase64 !== 'string') {
     return res.status(400).json({ error: 'imageBase64 is required' });
@@ -65,9 +60,19 @@ app.post('/api/segment', async (req, res) => {
     console.error(err);
     return res.status(500).json({ error: 'Unexpected server error' });
   }
-});
+};
 
-const port = process.env.PORT || 3000;
-app.listen(port, () => {
-  console.log(`Segment service listening on port ${port}`);
-});
+export function createApp() {
+  const app = express();
+  app.use(cors());
+  app.use(express.json({ limit: '20mb' }));
+  app.post('/api/segment', segmentHandler);
+  return app;
+}
+
+if (require.main === module) {
+  const port = process.env.PORT || 3000;
+  createApp().listen(port, () => {
+    console.log(`Segment service listening on port ${port}`);
+  });
+}

--- a/src/modules/__tests__/camera.test.ts
+++ b/src/modules/__tests__/camera.test.ts
@@ -1,0 +1,20 @@
+import { Camera } from '../camera';
+
+describe('Camera', () => {
+  it('captures video frame to canvas', () => {
+    const video = document.createElement('video');
+    Object.defineProperty(video, 'videoWidth', { value: 320 });
+    Object.defineProperty(video, 'videoHeight', { value: 240 });
+
+    const canvas = document.createElement('canvas');
+    const ctx = { drawImage: jest.fn() } as any;
+    (canvas as any).getContext = jest.fn().mockReturnValue(ctx);
+
+    const camera = new Camera(video);
+    camera.capture(canvas);
+
+    expect(canvas.width).toBe(320);
+    expect(canvas.height).toBe(240);
+    expect(ctx.drawImage).toHaveBeenCalledWith(video, 0, 0, 320, 240);
+  });
+});

--- a/src/modules/__tests__/colorMap.test.ts
+++ b/src/modules/__tests__/colorMap.test.ts
@@ -1,0 +1,17 @@
+import { loadColorMap, colorToProtoComp } from '../colorMap';
+
+describe('colorMap', () => {
+  it('loads mapping from JSON', async () => {
+    const mockMap = { protoA: { comp1: 'Red' } };
+    const originalFetch = global.fetch;
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => mockMap,
+    }) as any;
+
+    await loadColorMap();
+    expect(colorToProtoComp['Red']).toEqual({ protocol: 'protoA', component: 'comp1' });
+
+    global.fetch = originalFetch;
+  });
+});

--- a/src/modules/__tests__/legoBoardAnalyzer.test.ts
+++ b/src/modules/__tests__/legoBoardAnalyzer.test.ts
@@ -1,0 +1,17 @@
+import { LegoBoardAnalyzer } from '../legoBoardAnalyzer';
+import Color from 'colorjs.io';
+
+jest.mock('@techstark/opencv-js', () => ({}));
+
+describe('LegoBoardAnalyzer', () => {
+  it('matches color using deltaE', () => {
+    const analyzer = new LegoBoardAnalyzer({ segment: jest.fn() } as any);
+    const redRGB: [number, number, number] = [231, 0, 0];
+    const color = new Color('srgb', redRGB.map(v => v / 255) as any);
+    const lab = color.to('lab').coords as [number, number, number];
+    const openCvLab: [number, number, number] = [lab[0] * 255 / 100, lab[1] + 128, lab[2] + 128];
+    const res = (analyzer as any).matchColorWithDE(openCvLab);
+    expect(res.name).toBe('Red');
+    expect(res.deltaE).toBeCloseTo(0);
+  });
+});

--- a/src/modules/__tests__/legoColors.test.ts
+++ b/src/modules/__tests__/legoColors.test.ts
@@ -1,0 +1,9 @@
+import { legoColors } from '../legoColors';
+
+describe('legoColors', () => {
+  it('contains Red color definition', () => {
+    const red = legoColors.find(c => c.name === 'Red');
+    expect(red).toBeDefined();
+    expect(red?.rgb).toEqual([231, 0, 0]);
+  });
+});

--- a/src/modules/__tests__/segmentation.test.ts
+++ b/src/modules/__tests__/segmentation.test.ts
@@ -1,0 +1,30 @@
+import { LegoSegmenter, Prediction } from '../segmentation';
+
+describe('LegoSegmenter', () => {
+  afterEach(() => {
+    (global.fetch as any) = undefined;
+  });
+
+  it('posts image and returns predictions', async () => {
+    const canvas = document.createElement('canvas');
+    (canvas as any).toDataURL = () => 'data:image/jpeg;base64,aaaa';
+    const prediction: Prediction = { mask: '', x: 0, y: 0, width: 1, height: 1, points: [] };
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ predictions: [prediction] }),
+    }) as any;
+    const seg = new LegoSegmenter();
+    const res = await seg.segment(canvas);
+    expect(res).toEqual([prediction]);
+    expect(fetch).toHaveBeenCalledWith('/api/segment', expect.any(Object));
+  });
+
+  it('returns null on error', async () => {
+    const canvas = document.createElement('canvas');
+    (canvas as any).toDataURL = () => 'data:image/jpeg;base64,aaaa';
+    global.fetch = jest.fn().mockResolvedValue({ ok: false, status: 500, statusText: 'err' }) as any;
+    const seg = new LegoSegmenter();
+    const res = await seg.segment(canvas);
+    expect(res).toBeNull();
+  });
+});

--- a/src/modules/__tests__/vision.test.ts
+++ b/src/modules/__tests__/vision.test.ts
@@ -1,0 +1,73 @@
+import { VisionApp } from '../vision';
+import { Camera } from '@modules/camera';
+import { LegoSegmenter } from '@modules/segmentation';
+import { LegoBoardAnalyzer } from '@modules/legoBoardAnalyzer';
+import { loadColorMap } from '@modules/colorMap';
+
+jest.mock('@modules/camera');
+jest.mock('@modules/segmentation');
+jest.mock('@modules/legoBoardAnalyzer');
+jest.mock('@modules/colorMap', () => ({ loadColorMap: jest.fn() }));
+jest.mock('@modules/ui', () => ({ showLoadingIndicator: jest.fn() }));
+jest.mock('@techstark/opencv-js', () => ({}));
+
+describe('VisionApp', () => {
+  function setup() {
+    const video = document.createElement('video');
+    Object.defineProperty(video, 'videoWidth', { value: 100 });
+    Object.defineProperty(video, 'videoHeight', { value: 200 });
+    const capture = document.createElement('canvas');
+    (capture as any).getContext = jest.fn().mockReturnValue({});
+    const overlay = document.createElement('canvas');
+    const ctx = {
+      setTransform: jest.fn(),
+      clearRect: jest.fn(),
+      beginPath: jest.fn(),
+      moveTo: jest.fn(),
+      lineTo: jest.fn(),
+      closePath: jest.fn(),
+      stroke: jest.fn(),
+      measureText: jest.fn().mockReturnValue({ width: 10 }),
+      fillText: jest.fn(),
+      strokeStyle: '',
+      lineWidth: 0,
+      font: '',
+      fillStyle: '',
+    } as any;
+    (overlay as any).getContext = jest.fn().mockReturnValue(ctx);
+    (overlay as any).getBoundingClientRect = () => ({width:100, height:200} as DOMRect);
+    return { video, capture, overlay, ctx };
+  }
+
+  it('starts camera and loads color map', async () => {
+    const { video, capture, overlay } = setup();
+    const startMock = jest.fn();
+    (Camera as any).mockImplementation(() => ({ start: startMock, capture: jest.fn() }));
+    (LegoSegmenter as any).mockImplementation(() => ({}));
+    (LegoBoardAnalyzer as any).mockImplementation(() => ({ analyze: jest.fn() }));
+    (loadColorMap as jest.Mock).mockResolvedValue(undefined);
+
+    const app = new VisionApp(video, capture, overlay);
+    await app.start();
+    expect(startMock).toHaveBeenCalled();
+    expect(loadColorMap).toHaveBeenCalled();
+    expect(capture.width).toBe(100);
+    expect(capture.height).toBe(200);
+  });
+
+  it('captures and analyzes', async () => {
+    const { video, capture, overlay } = setup();
+    const captureMock = jest.fn();
+    const analyzeMock = jest.fn().mockResolvedValue([]);
+    (Camera as any).mockImplementation(() => ({ start: jest.fn(), capture: captureMock }));
+    (LegoSegmenter as any).mockImplementation(() => ({}));
+    (LegoBoardAnalyzer as any).mockImplementation(() => ({ analyze: analyzeMock }));
+    (loadColorMap as jest.Mock).mockResolvedValue(undefined);
+
+    const app = new VisionApp(video, capture, overlay);
+    await app.start();
+    await app.analyze();
+    expect(captureMock).toHaveBeenCalledWith(capture);
+    expect(analyzeMock).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for camera capture, color map loading, color matching, segmenter, vision app, and segmentation service
- refactor segmentService to export handler and app factory for easier testing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f310292dc83308fc6263b3c5a5a6d